### PR TITLE
Add support for Nvim term cursor

### DIFF
--- a/colors/parchment.vim
+++ b/colors/parchment.vim
@@ -177,4 +177,25 @@ call s:Style("SpellCap",       s:green,       [],             "undercurl")
 call s:Style("SpellRare",      s:green,       [],             "undercurl")
 call s:Style("SpellLocal",     s:green,       [],             "undercurl")
 
+if has('nvim')
+      hi! link TermCursor Cursor
+      hi TermCursorNC ctermfg=235 ctermbg=242 guifg=#002b36 guibg=#586e75 guisp=NONE cterm=NONE gui=NONE
+      let g:terminal_color_8='#002b36'
+      let g:terminal_color_0='#073642'
+      let g:terminal_color_10='#586e75'
+      let g:terminal_color_11='#657b83'
+      let g:terminal_color_12='#839496'
+      let g:terminal_color_14='#93a1a1'
+      let g:terminal_color_7='#eee8d5'
+      let g:terminal_color_15='#fdf6e3'
+      let g:terminal_color_3='#b58900'
+      let g:terminal_color_9='#cb4b16'
+      let g:terminal_color_1='#dc322f'
+      let g:terminal_color_5='#d33682'
+      let g:terminal_color_13='#6c71c4'
+      let g:terminal_color_4='#268bd2'
+      let g:terminal_color_6='#2aa198'
+      let g:terminal_color_2='#859900'
+endif
+
 " }}}

--- a/colors/parchment.vim
+++ b/colors/parchment.vim
@@ -180,22 +180,6 @@ call s:Style("SpellLocal",     s:green,       [],             "undercurl")
 if has('nvim')
       hi! link TermCursor Cursor
       hi TermCursorNC ctermfg=235 ctermbg=242 guifg=#002b36 guibg=#586e75 guisp=NONE cterm=NONE gui=NONE
-      let g:terminal_color_8='#002b36'
-      let g:terminal_color_0='#073642'
-      let g:terminal_color_10='#586e75'
-      let g:terminal_color_11='#657b83'
-      let g:terminal_color_12='#839496'
-      let g:terminal_color_14='#93a1a1'
-      let g:terminal_color_7='#eee8d5'
-      let g:terminal_color_15='#fdf6e3'
-      let g:terminal_color_3='#b58900'
-      let g:terminal_color_9='#cb4b16'
-      let g:terminal_color_1='#dc322f'
-      let g:terminal_color_5='#d33682'
-      let g:terminal_color_13='#6c71c4'
-      let g:terminal_color_4='#268bd2'
-      let g:terminal_color_6='#2aa198'
-      let g:terminal_color_2='#859900'
 endif
 
 " }}}


### PR DESCRIPTION
See http://vimcasts.org/episodes/neovim-terminal-paste/ for better explanation how terminal in neovim works and that it is pleasant to see the difference between the terminal cursor and shell cursor.

I really don't understand what's going so I have just lifted up [one ``if`` statement](https://github.com/lifepillar/vim-solarized8/blob/master/colors/solarized8.vim#L377-L379) from ``solarized8`` and then randomly removed all manipulation with ``g:terminal_color_*`` variables. So, this should be considered more like just a RFE which should be fixed by somebody who actually knows what she is talking about.